### PR TITLE
Allow iodized to override on a per session basis

### DIFF
--- a/lib/iodized.rb
+++ b/lib/iodized.rb
@@ -22,6 +22,14 @@ module Iodized
     @client ||= Iodized::Client.new
   end
 
+  def self.override_for_session(feature, feature_value)
+    client.override_for_session(feature, feature_value)
+  end
+
+  def self.overriden_for_session?(feature)
+    client.overriden_for_session?(feature)
+  end
+
   def self.client=(client)
     @client = client
   end


### PR DESCRIPTION
Can be overridden to be true or false. Passing nil will clear the override.

Usage:

``` ruby
# Set the feature true for this session
Iodized. override_for_session("feature_name", true)

# Determine whether the feature has been overridden
Iodized.overriden_for_session?(feature)

# Clear the feature for this session
Iodized.override_for_session("feature_name", nil)
```
